### PR TITLE
Fix build directory issue

### DIFF
--- a/app/api/seed/route.ts
+++ b/app/api/seed/route.ts
@@ -1,8 +1,17 @@
 import { db, products } from 'lib/db';
+import fs from 'fs';
+import path from 'path';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET() {
+  const baseDir = '/opt/build';
+
+  if (!fs.existsSync(baseDir)) {
+    fs.mkdirSync(baseDir, { recursive: true });
+    console.log(`Directory created: ${baseDir}`);
+  }
+
   const existingProducts = await db.select().from(products).limit(1);
 
   if (existingProducts.length > 0) {


### PR DESCRIPTION
Update the `GET` function in `app/api/seed/route.ts` to handle the base directory issue.

* Import `fs` and `path` modules.
* Define `baseDir` as `/opt/build`.
* Check if the directory exists, and if not, create it.
* Log a message indicating the creation of the directory.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JC9mm/admin-dashboard/pull/10?shareId=69dded1c-0aac-4ed0-99de-13aff39fee82).